### PR TITLE
Fix services layer not fetching last observation

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -52,8 +52,8 @@ export const getObservationsEndpoint = ({
 }: GetObservationsEndpointParams): string => {
   let url = `${SENSORTHINGS_BASE}/Datastreams('${id}')/Observations?$resultFormat=dataArray`
   url += `&$top=${pageSize}`
-  url += `&$filter=phenomenonTime%20ge%20${startTime}`
-  if (endTime) url += `%20and%20phenomenonTime%20lt%20${endTime}`
+  url += `&$filter=phenomenonTime%20gt%20${startTime}`
+  if (endTime) url += `%20and%20phenomenonTime%20le%20${endTime}`
   if (skipCount) url += `&$skip=${skipCount}`
   if (addResultQualifiers) url += `&$select=phenomenonTime,result,resultQuality`
   return url


### PR DESCRIPTION
Resolves hydroserver2/hydroserver#221

I changed the lower end of an observations fetch to be > rather than >= and the upper end to be <= rather than <. This fixes the problem where the latest observation wasn't being fetched by the frontend. The lower end needed to change too so that duplicate values aren't fetched if someone increases the time range.